### PR TITLE
Use Axis hints from Makie 0.24.11

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,7 +11,7 @@ Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 
 [compat]
 KernelDensity = "0.6.9"
-Makie = "0.24"
+Makie = "0.24.11"
 Statistics = "1"
 julia = "1.10"
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # BigRiverMakie.jl
 
-[![Build Status](https://github.com/senresearch/BigRiverMakie.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/senresearch/BigRiverMakie.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![CI](https://github.com/senresearch/BigRiverMakie.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/senresearch/BigRiverMakie.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Stable](https://img.shields.io/badge/docs-stable-blue.svg)](https://senresearch.github.io/BigRiverMakie.jl/stable)
+[![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://senresearch.github.io/BigRiverMakie.jl/dev)
+[![codecov](https://codecov.io/gh/senresearch/BigRiverMakie.jl/graph/badge.svg?token=FFRLyzBmUd)](https://codecov.io/gh/senresearch/BigRiverMakie.jl)
+[![License: AGPL v3](https://img.shields.io/badge/License-AGPL_v3-blue.svg)](https://www.gnu.org/licenses/agpl-3.0)
 
 A package built on top of [Makie.jl](https://makie.org/) that provides sets of recipes for plots commonly used with [BigRiverMetabolomics.jl](https://github.com/senresearch/BigRiverMetabolomics.jl).

--- a/docs/src/confidence.md
+++ b/docs/src/confidence.md
@@ -16,7 +16,7 @@ function generate_confidence_data(n::Int = 8)
     # categories = ["Treatment A", "Treatment B", "Control", "Placebo", 
     #               "Method 1", "Method 2", "Baseline", "Enhanced"]
 
-    return x_data, categories, errors
+    return x_data, (1:n, categories), errors
 end
 
 x_data, y_labels, error_values = generate_confidence_data(6)
@@ -25,11 +25,10 @@ x_data, y_labels, error_values = generate_confidence_data(6)
 ```@example example_data
 using CairoMakie, BigRiverMakie
 
-confidence_plot(x_data, y_labels, error_values)
+confidenceplot(x_data, error_values, axis = (yticks = y_labels, ))
 ```
 
 ```@docs
-BigRiverMakie.confidence_plot
 BigRiverMakie.confidenceplot
 BigRiverMakie.confidenceplot!
 BigRiverMakie.ConfidencePlot

--- a/docs/src/dotplot.md
+++ b/docs/src/dotplot.md
@@ -6,11 +6,11 @@ This plot shows the distribution of data points in each category. The yellow poi
 function generate_dotplot_data(n_categories::Int = 4, points_per_category::Int = 20)
     # Generate category labels
     categories = ["Group $i" for i in 1:n_categories]
-    
+
     # Generate data points for each category
     x_indices = Int[]
     y_values = Float64[]
-    
+
     for (i, category) in enumerate(categories)
         # Generate random data points for this category
         # Use different normal distributions with different means to show variety
@@ -27,12 +27,12 @@ function generate_dotplot_data(n_categories::Int = 4, points_per_category::Int =
             # Normal distribution centered around 1.0
             group_data = randn(points_per_category) * 0.4 .+ 1.0
         end
-        
+
         # Add category index and data points
         append!(x_indices, fill(i, points_per_category))
         append!(y_values, group_data)
     end
-    
+
     return x_indices, y_values, categories
 end
 
@@ -50,7 +50,7 @@ algs = [:none, :random, :quasirandom]
 fig = Figure(; size = (1000, 400))
 axs = [Axis(fig[1, i]) for i in 1:3]
 for (i, alg) in enumerate(algs)
-    dot_plot!(axs[i], x_indices, y_values, categories; color = (:blue, 0.5), jitter_alg = alg, jitter_width = 0.5)
+    dotplot!(axs[i], x_indices, y_values, categories; color = (:blue, 0.5), jitter_alg = alg, jitter_width = 0.5)
     axs[i].title = "Jitter algorithm: $alg"
 end
 
@@ -58,7 +58,6 @@ fig
 ```
 
 ```@docs
-BigRiverMakie.dot_plot
 BigRiverMakie.dotplot
 BigRiverMakie.dotplot!
 BigRiverMakie.DotPlot

--- a/src/BigRiverMakie.jl
+++ b/src/BigRiverMakie.jl
@@ -5,9 +5,9 @@ using Statistics
 using KernelDensity
 
 include("confidence.jl")
-export confidence_plot, confidence_plot!, confidenceplot, confidenceplot!
+export confidenceplot, confidenceplot!
 
 include("dotplot.jl")
-export dot_plot, dot_plot!, dotplot, dotplot!
+export dotplot, dotplot!
 
 end

--- a/src/confidence.jl
+++ b/src/confidence.jl
@@ -1,58 +1,4 @@
 """
-    confidence_plot(x_data, y_labels, error_values; kwargs...)
-
-Generates a confidence interval plot around `x_data` with error bars as given by `error_values`.
-The y-axis is labeled with `y_labels`.
-
-# Arguments
-
-- `x_data`: A vector of x values.
-- `y_labels`: A vector of y labels.
-- `error_values`: A vector of error values.
-- `kwargs`: Additional arguments to pass to the `confidenceplot!` function.
-"""
-function confidence_plot(
-        x_data::Vector{<:Real},
-        y_labels::Vector{<:AbstractString},
-        error_values::Vector{<:Real};
-        kwargs...
-    )
-    fig = Figure()
-    ax = Axis(
-        fig[1, 1],
-        yticks = (1:length(y_labels), y_labels),
-        xlabel = "Effect Size",
-        title = "Confidence Interval Plot",
-        leftspinevisible = false,
-        rightspinevisible = false,
-        topspinevisible = false,
-        xgridvisible = false,
-        ygridvisible = false,
-        yticksvisible = false
-    )
-    confidenceplot!(ax, x_data, error_values; kwargs...)
-    return fig
-end
-
-function confidence_plot!(
-        ax,
-        x_data::Vector{<:Real},
-        y_labels::Vector{<:AbstractString},
-        error_values::Vector{<:Real};
-        kwargs...
-    )
-    ax.yticks = (1:length(y_labels), y_labels)
-    ax.xlabel = "Effect Size"
-    ax.title = "Confidence Interval Plot"
-    ax.xgridvisible = false
-    ax.ygridvisible = false
-    ax.yticksvisible = false
-    ax.leftspinevisible = false
-    ax.rightspinevisible = false
-    return confidenceplot!(ax, x_data, error_values; kwargs...)
-end
-
-"""
     confidenceplot!(x, ϵ; kwargs...)
     confidenceplot(x, ϵ; kwargs...)
 
@@ -63,7 +9,7 @@ the point is colored dark blue, otherwise it is colored light blue.
 
 This plot is a Makie recipe and does not set any theming options, or even the axis labels. It can
 of course be customized with the same variety that any Makie plot can be, but for a plot with more
-default options and the choice to pass in axis labels, see also [`confidence_plot`](@ref).
+default options and the choice to pass in axis labels, see also [`confidenceplot`](@ref).
 
 # Arguments
 
@@ -135,4 +81,14 @@ function Makie.plot!(p::ConfidencePlot)
     )
     vlines!(p, 0; color = p.linecolor, linestyle = p.linestyle)
     return p
+end
+
+function Makie.preferred_axis_attributes(::Type{Axis}, ::ConfidencePlot)
+    return (
+        yticks = (1:length(y_labels), y_labels),
+        xgridvisible = false, ygridvisible = false,
+        leftspinevisible = false, rightspinevisible = false,
+        topspinevisible = false, yticksvisible = false,
+        title = "Confidence Interval Plot", xlabel = "Effect Size"
+    )
 end

--- a/src/dotplot.jl
+++ b/src/dotplot.jl
@@ -1,53 +1,4 @@
 """
-    dot_plot(x, y, x_labels; kwargs...)
-
-
-Plots a dotplot. The x values are the categories and the y values are the data points.
-The x_labels are the labels for the x values.
-
-# Arguments
-- `x`: The x values.
-- `y`: The y values.
-- `x_labels`: The labels for the x values.
-- `kwargs`: Additional arguments to pass to the `dotplot!` function.
-"""
-function dot_plot(x::Vector{<:Real}, y::Vector{<:Real}, x_labels::Vector{<:String}; kwargs...)
-    fig = Figure()
-    ax = Axis(
-        fig[1, 1],
-        xticks = (1:length(x_labels), x_labels),
-        xlabel = "Super Class",
-        title = "Dot Plot",
-        leftspinevisible = false,
-        rightspinevisible = false,
-        topspinevisible = false,
-        xgridvisible = false,
-        ygridvisible = false,
-        yticksvisible = false
-    )
-    dotplot!(ax, x, y; kwargs...)
-    return fig
-end
-
-function dot_plot!(
-        ax,
-        x::Vector{<:Real},
-        y::Vector{<:Real},
-        x_labels::Vector{<:String};
-        kwargs...
-    )
-    ax.xticks = (1:length(x_labels), x_labels)
-    ax.xlabel = "Super Class"
-    ax.title = "Dot Plot"
-    ax.xgridvisible = false
-    ax.ygridvisible = false
-    ax.yticksvisible = false
-    ax.leftspinevisible = false
-    ax.rightspinevisible = false
-    return dotplot!(ax, x, y; kwargs...)
-end
-
-"""
     dotplot(x, y; kwargs...)
     dotplot!(x, y; kwargs...)
 
@@ -95,6 +46,15 @@ central points. The central points represent each category.
 
     # All other attributes of Scatter are inherited and passed to the scatter plot
     Makie.documented_attributes(Scatter)...
+end
+
+function Makie.preferred_axis_attributes(::Type{Axis}, ::DotPlot)
+    return (
+        xgridvisible = false, ygridvisible = false,
+        leftspinevisible = false, rightspinevisible = false,
+        topspinevisible = false, yticksvisible = false,
+        title = "Dot Plot", xlabel = "Super Class"
+    )
 end
 
 function Makie.plot!(p::DotPlot)

--- a/test/confidence_tests.jl
+++ b/test/confidence_tests.jl
@@ -1,4 +1,4 @@
-@testitem "confidence_plot basic functionality" begin
+@testitem "confidenceplot basic functionality" begin
     using Test
     using BigRiverMakie
     import Makie: Figure, Axis
@@ -7,13 +7,13 @@
     y_labels = ["A", "B", "C", "D", "E"]
     error_values = [0.2, 0.15, 0.3, 0.25, 0.18]
 
-    fig = confidence_plot(x_data, y_labels, error_values)
+    fig = confidenceplot(x_data, error_values, y_labels)
 
     @test fig isa Figure
     @test length(fig.content) > 0
 end
 
-@testitem "confidence_plot! basic functionality" begin
+@testitem "confidenceplot! basic functionality" begin
     using Test
     using BigRiverMakie
     import Makie: Figure, Axis
@@ -25,7 +25,7 @@ end
     y_labels = ["A", "B", "C", "D", "E"]
     error_values = [0.2, 0.15, 0.3, 0.25, 0.18]
 
-    confidence_plot!(ax, x_data, y_labels, error_values)
+    confidenceplot!(ax, x_data, y_labels, error_values)
 
     @test ax.yticks[] == (1:5, ["A", "B", "C", "D", "E"])
     @test ax.xlabel[] == "Effect Size"

--- a/test/dotplot_tests.jl
+++ b/test/dotplot_tests.jl
@@ -1,4 +1,4 @@
-@testitem "dot_plot basic functionality" begin
+@testitem "dotplot basic functionality" begin
     using Test
     using BigRiverMakie
     import Makie: Figure, Axis
@@ -7,13 +7,13 @@
     y = [0.5, 1.2, -0.3, 0.8, 1.5, -0.7]
     x_labels = ["A", "B", "C"]
 
-    fig = dot_plot(x, y, x_labels)
+    fig = dotplot(x, y, x_labels)
 
     @test fig isa Figure
     @test length(fig.content) > 0
 end
 
-@testitem "dot_plot! basic functionality" begin
+@testitem "dotplot! basic functionality" begin
     using Test
     using BigRiverMakie
     import Makie: Figure, Axis
@@ -25,7 +25,7 @@ end
     y = [0.5, 1.2, -0.3, 0.8, 1.5, -0.7]
     x_labels = ["A", "B", "C"]
 
-    dot_plot!(ax, x, y, x_labels)
+    dotplot!(ax, x, y, x_labels)
 
     @test ax.xticks[] == (1:3, ["A", "B", "C"])
     @test ax.xlabel[] == "Super Class"


### PR DESCRIPTION
Makie 0.24.11 adds axis hints (see https://github.com/MakieOrg/Makie.jl/pull/5375 and https://docs.makie.org/dev/explanations/recipes#Axis-Utilities for more details), which allow there to be preferred axis attributes set for recipes. This PR shifts the burden of theming to the recipe, avoiding the need for bespoke functions for the plots. Still in progress.

- [ ] Decide on function signature changes. Potentially breaking release to accommodate this?
- [ ] Update tests